### PR TITLE
begin_calibrate raises when it can no longer continue (instead of return)

### DIFF
--- a/xicam/SAXS/stages/__init__.py
+++ b/xicam/SAXS/stages/__init__.py
@@ -481,9 +481,12 @@ class CalibrateGUIPlugin(BaseSAXSGUIPlugin):
         # get catalogs from active ensemble
         active_ensemble = self.ensemble_model.active_ensemble
         if not active_ensemble:
-            return
+            raise RuntimeError("Unable to calibrate since there is no data currently loaded. "
+                               "Try opening data from the data browser on the left, "
+                               "then retry running the calibration workflow.")
 
-        active_catalogs = self.ensemble_model.catalogs_from_ensemble(active_ensemble)
+        # [] handles case where there is an active ensemble but no catalogs under it
+        active_catalogs = self.ensemble_model.catalogs_from_ensemble(active_ensemble) or []
 
         class CalibrationDialog(QDialog):
             """Dialog for calibrating images.
@@ -530,8 +533,9 @@ class CalibrateGUIPlugin(BaseSAXSGUIPlugin):
                 return self._catalogs[self.catalog_selector.currentRow()]
 
         if not active_catalogs:
-            msg.logMessage("No catalogs in active ensemble found, cannot calibrate.", msg.WARNING)
-            return
+            raise RuntimeError("There are no catalogs in the active ensemble "
+                               f'"{active_ensemble.data(Qt.DisplayRole)}". '
+                               "Unable to calibrate.")
 
         dialog = CalibrationDialog(active_catalogs)
         accepted = dialog.exec_()


### PR DESCRIPTION
See https://github.com/Xi-CAM/Xi-cam/pull/76.

The `begin_calibrate` function in the calibration stage acts as a kwargs_callable for the calibration workflow that is set up in the linear workflow editor. If this fails (there is no active ensemble / no data loaded, or there are no catalogs in the active ensemble), then we want to raise a `RuntimeError` that has some useful information for the user.

The `WorkflowEditor.run_workflow` method that called the kwargs_callable will catch this exception, log a more detailed error message, and will not continue later in the function to execute the workflow.

Previously, this function was just returning None when an invalid state for calibration occurred; this did not interrupt the eventual execution of the workflow, so errors would occur in the operations being run.