### PR TITLE
Add bg-correction mixin for xpcs (WIP)

### DIFF
--- a/xicam/SAXS/canvases/__init__.py
+++ b/xicam/SAXS/canvases/__init__.py
@@ -18,7 +18,7 @@ class SAXSToolbarMixin(ToolbarLayout):
 
 # FIXME: investigate EWaldCorrected (particularly ProcessingView) -- causes "tuple indexing error" on ProxyView when opening image
 @live_plugin("ImageMixinPlugin")
-class SAXSImageIntentBlend(BackgroundCorrected, LogScaleIntensity, CenterMarker, BetterButtons, QCoordinates,
+class SAXSImageIntentBlend(BackgroundCorrected, LogScaleIntensity, CenterMarker, BetterButtons, Crosshair, QCoordinates,
                            ImageViewHistogramOverflowFix, ROICreator, EwaldCorrected):  # LogButtons):
     ...
 

--- a/xicam/SAXS/canvases/__init__.py
+++ b/xicam/SAXS/canvases/__init__.py
@@ -1,13 +1,11 @@
-import numpy as np
-from pyqtgraph import ImageView
-from xarray import DataArray
-
 from xicam.SAXS.widgets.SAXSToolbar import SAXSToolbarBase, ROIs
 from xicam.plugins import manager as plugin_manager
 from xicam.plugins import live_plugin
 from xicam.gui.canvases import ImageIntentCanvas
 from xicam.gui.widgets.imageviewmixins import LogScaleIntensity, ImageViewHistogramOverflowFix, \
     QCoordinates, Crosshair, BetterButtons, CenterMarker, ToolbarLayout, EwaldCorrected, ROICreator
+
+from xicam.SAXS.widgets.imageviewmixins import BackgroundCorrected
 
 
 @live_plugin("ImageMixinPlugin")
@@ -20,7 +18,7 @@ class SAXSToolbarMixin(ToolbarLayout):
 
 # FIXME: investigate EWaldCorrected (particularly ProcessingView) -- causes "tuple indexing error" on ProxyView when opening image
 @live_plugin("ImageMixinPlugin")
-class SAXSImageIntentBlend(LogScaleIntensity, CenterMarker, BetterButtons, Crosshair, QCoordinates,
+class SAXSImageIntentBlend(BackgroundCorrected, LogScaleIntensity, CenterMarker, BetterButtons, QCoordinates,
                            ImageViewHistogramOverflowFix, ROICreator, EwaldCorrected):  # LogButtons):
     ...
 
@@ -33,3 +31,5 @@ class SAXSImageIntentCanvas(ImageIntentCanvas):
         super(SAXSImageIntentCanvas, self).render(intent, mixins=["SAXSImageIntentBlend"])
         if hasattr(intent, "geometry"):
             self.canvas_widget.setGeometry(intent.geometry)
+        if hasattr(intent, "darks") and hasattr(self.canvas_widget, "set_darks"):
+            self.canvas_widget.set_darks(intent._darks)

--- a/xicam/SAXS/widgets/imageviewmixins.py
+++ b/xicam/SAXS/widgets/imageviewmixins.py
@@ -1,0 +1,58 @@
+from databroker import Broker
+from qtpy.QtWidgets import QPushButton, QSizePolicy
+import numpy as np
+
+from xicam.gui.widgets.imageviewmixins import BetterLayout, ProcessingView, XArrayView
+
+from xicam.SAXS.operations.correction import correct
+
+
+class BackgroundCorrected(BetterLayout, ProcessingView):
+    """Toggle background correction for an image or image series."""
+    def __init__(self, *args, darks=None, **kwargs):
+        super(BackgroundCorrected, self).__init__(*args, **kwargs)
+        self._darks = None
+        self._bg_correction = False
+        self._bg_correct_btn = QPushButton("BG Correction")
+        self._bg_correct_btn.setEnabled(False)
+        self._bg_correct_btn.setCheckable(True)
+        self._bg_correct_btn.clicked.connect(self._toggle_bg_correction)
+        size_policy = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
+        size_policy.setHorizontalStretch(0)
+        size_policy.setVerticalStretch(1)
+        size_policy.setHeightForWidth(self._bg_correct_btn.sizePolicy().hasHeightForWidth())
+        self._bg_correct_btn.setSizePolicy(size_policy)
+
+        self.set_darks(darks)
+
+        self.ui.right_layout.addWidget(self._bg_correct_btn)
+
+    def setImage(self, img, *args, darks=None, **kwargs):
+        """Override to add additional `darks` kwarg for dark image."""
+        super(BackgroundCorrected, self).setImage(img, *args, **kwargs)
+        if darks is not None and self._darks is not None:
+            self._darks = darks
+        self.set_darks(darks)  # Can't do this before... self.image won't be set until super call
+
+    def set_darks(self, darks):
+        """Set dark image for this image view."""
+        if darks is not None:
+            self._darks = darks
+            self._bg_correct_btn.setEnabled(True)
+            self._toggle_bg_correction(True)
+
+    def _toggle_bg_correction(self, value):
+        """Slot to handle when bg correction button is clicked."""
+        self._bg_correction = value
+        self._bg_correct_btn.setChecked(value)
+        self.getProcessedImage()  # TODO: how do we make this work for a single frame image / update current frame?
+
+    def process(self, image):
+        """Either returns the raw image or the correct image, depending on the bg correction button state."""
+        if self._bg_correction:
+            flats = np.ones_like(image)
+            if self._darks is None:
+                return image
+            else:
+                return correct(np.expand_dims(image, 0), flats, self._darks)[0]
+        return image

--- a/xicam/SAXS/widgets/imageviewmixins.py
+++ b/xicam/SAXS/widgets/imageviewmixins.py
@@ -2,7 +2,7 @@ from databroker import Broker
 from qtpy.QtWidgets import QPushButton, QSizePolicy
 import numpy as np
 
-from xicam.gui.widgets.imageviewmixins import BetterLayout, ProcessingView, XArrayView
+from xicam.gui.widgets.imageviewmixins import BetterLayout, ProcessingView
 
 from xicam.SAXS.operations.correction import correct
 
@@ -10,29 +10,29 @@ from xicam.SAXS.operations.correction import correct
 class BackgroundCorrected(BetterLayout, ProcessingView):
     """Toggle background correction for an image or image series."""
     def __init__(self, *args, darks=None, **kwargs):
-        super(BackgroundCorrected, self).__init__(*args, **kwargs)
         self._darks = None
+        self.set_darks(darks)
         self._bg_correction = False
         self._bg_correct_btn = QPushButton("BG Correction")
         self._bg_correct_btn.setEnabled(False)
         self._bg_correct_btn.setCheckable(True)
         self._bg_correct_btn.clicked.connect(self._toggle_bg_correction)
+
+        super(BackgroundCorrected, self).__init__(*args, **kwargs)
+
         size_policy = QSizePolicy(QSizePolicy.Minimum, QSizePolicy.Fixed)
         size_policy.setHorizontalStretch(0)
         size_policy.setVerticalStretch(1)
         size_policy.setHeightForWidth(self._bg_correct_btn.sizePolicy().hasHeightForWidth())
         self._bg_correct_btn.setSizePolicy(size_policy)
-
-        self.set_darks(darks)
-
         self.ui.right_layout.addWidget(self._bg_correct_btn)
 
     def setImage(self, img, *args, darks=None, **kwargs):
         """Override to add additional `darks` kwarg for dark image."""
-        super(BackgroundCorrected, self).setImage(img, *args, **kwargs)
         if darks is not None and self._darks is not None:
             self._darks = darks
         self.set_darks(darks)  # Can't do this before... self.image won't be set until super call
+        super(BackgroundCorrected, self).setImage(img, *args, **kwargs)
 
     def set_darks(self, darks):
         """Set dark image for this image view."""
@@ -45,7 +45,14 @@ class BackgroundCorrected(BetterLayout, ProcessingView):
         """Slot to handle when bg correction button is clicked."""
         self._bg_correction = value
         self._bg_correct_btn.setChecked(value)
-        self.getProcessedImage()  # TODO: how do we make this work for a single frame image / update current frame?
+        index = self.currentIndex
+        self.setImage(self.image, autoRange=False)  # Reprocess the current frame
+        if self.image is not None:
+            try:
+                self.setCurrentIndex(index)
+            except TypeError as e:
+                # Ignore "tuple indices must be integers or slices, not NoneType" for 2d pseudo3framearray images
+                pass
 
     def process(self, image):
         """Either returns the raw image or the correct image, depending on the bg correction button state."""


### PR DESCRIPTION
Tested by opening the `local` databroker on `tsuru`, selecting **July 1** as the end date, and selecting the first catalog that appears (multi-frame image).

### TODOs:

- [x] Apply correction / no correction for current frame immediately when button is clicked
this fixes 2 things:
1. for single frame image, allow toggling on / off bg correction
2. for multi-frame image, allow updating the currently displayed frame when button is clicked 

I'm using the `getProcessedImage()` mechanism (that ProcessingView makes use of with its process method), and the Pseudo3DFrameArray only supports images with 3 dimensions. This may be one reason why this method doesn't work for a single-frame image.